### PR TITLE
Support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/view": "^6.0|^7.0|^8.0|^9.0"
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/view": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "laravel/framework": "^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/view": "^6.0|^7.0|^8.0"
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/view": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "laravel/framework": "^6.0|^7.0",


### PR DESCRIPTION
New version support for `illuminate/console` and `illuminate/view` to work with Laravel 9.
The package works on my own dev environment.